### PR TITLE
removed proc file

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: node ./app.js


### PR DESCRIPTION
The entry point given in proc file was wrong hence app was getting crashed. 

FYI you don't need to give an entry point explicitly to Heroku or any other deployment platform, they take it from package.json by default. 